### PR TITLE
Upgrade to buster, slimmer docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM docker.ocf.berkeley.edu/theocf/debian:stretch
+FROM docker.ocf.berkeley.edu/theocf/debian:buster
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nginx \
-        python3
+        python3 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 
 COPY www /srv/www
 COPY nginx.conf /srv/


### PR DESCRIPTION
Removing the apt cache moves from 334 MB to 299 MB. Not a great saving, but not bad for a simple change at least.

I tested the buster upgrade with a `make dev` and it all appeared to work fine (showed the lab was closed, some desktops were used as also listed on https://www.ocf.berkeley.edu/stats/).